### PR TITLE
Update to version 0.3.2

### DIFF
--- a/btdht/dht.pyx
+++ b/btdht/dht.pyx
@@ -976,7 +976,10 @@ cdef class DHT_BASE:
             # 1: premission denied
             # 10013: same as 1 but on windows
             if e.errno not in [11, 1, 10035, 10013]:
-                self.debug(0, "send:%r : (%r, %r)" % (e, data, addr))
+                try:
+                    self.debug(0, "recv:%r : (%r, %r)" % (e, data, addr))
+                except UnboundLocalError:
+                    self.debug(0, "recv:%r" % (e,))
                 raise
         except MissingT:
             pass

--- a/btdht/utils.pyx
+++ b/btdht/utils.pyx
@@ -843,13 +843,13 @@ class Scheduler(object):
         iterator = function()
         self._names[iterator] = name
         self._iterators[name] = iterator
-        typ = iterator.next()
+        typ = next(iterator)
         if typ == 0:
             if user == True:
                 raise ValueError("Only queue based threads can be put in the user loop")
             self._time_based[iterator] = 0
         elif typ == 1:
-            queue = iterator.next()
+            queue = next(iterator)
             if user == True:
                 self._user_queue[iterator] = queue
                 self._user_queue_sockets.append(queue.sock)
@@ -1062,7 +1062,7 @@ class Scheduler(object):
                         try:
                             for iterator, t in six.iteritems(self._time_based):
                                 if now >= t:
-                                    to_set.append((iterator, iterator.next()))
+                                    to_set.append((iterator, next(iterator)))
                             for iterator, t in to_set:
                                 self._time_based[iterator] = t
                         except RuntimeError:
@@ -1073,7 +1073,7 @@ class Scheduler(object):
                 for sock in sockets:
                     try:
                         iterator = self._queue_base_socket_map[sock]
-                        iterator.next()
+                        next(iterator)
                     except KeyError:
                         pass
         except StopIteration as error:
@@ -1107,7 +1107,7 @@ class Scheduler(object):
                 for sock in sockets:
                     try:
                         iterator = self._queue_base_socket_map[sock]
-                        iterator.next()
+                        next(iterator)
                     except KeyError:
                         pass
         except StopIteration as error:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     has_cython = False
 
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 if __name__ == "__main__":
     c_extensions = [


### PR DESCRIPTION
* Fix raise of a UnboundLocalError instead of a socket.error in _process_incoming_message
* Fix call to next method on iterator: In python3 iterator g.next() method is renamed to g.__next__()
  using next(g) works in python 2 and 3 
