### PR TITLE
Update to version 0.3.3

### DIFF
--- a/btdht/krcp.pyx
+++ b/btdht/krcp.pyx
@@ -1451,12 +1451,12 @@ cdef class BMessage:
     property addr:
         def __get__(self):
             if six.PY3:
-                if self.addr_addr_3 and self.addr_port:
+                if self.addr_addr_3 and self.addr_port > 0:
                     return (self.addr_addr_3, self.addr_port)
                 else:
                     return None
             else:
-                if self.addr_addr_2 and self.addr_port:
+                if self.addr_addr_2 and self.addr_port > 0:
                     return (self.addr_addr_2, self.addr_port)
                 else:
                     return None
@@ -1469,7 +1469,7 @@ cdef class BMessage:
                 self.addr_port = addr[1]
         def __del__(self):
             self.addr_addr = None
-            self.addr_port = None
+            self.addr_port = 0
 
     #: The ``y` key of the message. Possible value are ``"q"`` for a query, `"r"` for a response
     #: and ``"e"`` for an error.

--- a/make_wheel.bat
+++ b/make_wheel.bat
@@ -6,3 +6,7 @@ C:/Python35-32/python -m pip install wheel
 C:/Python35-32/python setup.py bdist_wheel
 C:/Python35/python -m pip install wheel
 C:/Python35/python setup.py bdist_wheel
+C:/Python36-32/python -m pip install wheel
+C:/Python36-32/python setup.py bdist_wheel
+C:/Python36/python -m pip install wheel
+C:/Python36/python setup.py bdist_wheel

--- a/make_wheel.bat
+++ b/make_wheel.bat
@@ -10,3 +10,7 @@ C:/Python36-32/python -m pip install wheel
 C:/Python36-32/python setup.py bdist_wheel
 C:/Python36/python -m pip install wheel
 C:/Python36/python setup.py bdist_wheel
+C:/Python37-32/python -m pip install wheel
+C:/Python37-32/python setup.py bdist_wheel
+C:/Python37/python -m pip install wheel
+C:/Python37/python setup.py bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     has_cython = False
 
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 if __name__ == "__main__":
     c_extensions = [


### PR DESCRIPTION
* Add python 3.6 and 3.7 to script compiling wheels for windows
* Fix enumerate_ids for python3
* In Cython 0.28 it is now forbbiden to assign None to a int, so we use 0
  instead for an address port.
