### PR TITLE
fix: ModuleNotFoundError: No module named 'utils'

### DIFF
--- a/btdht/dht.pyx
+++ b/btdht/dht.pyx
@@ -40,7 +40,7 @@ except ImportError:
 
 import datrie
 
-import utils
+from . import utils
 from .utils import ID, nbit, nflip, nset, PollableQueue
 from .exceptions import BucketFull, BucketNotFull, NoTokenError, FailToStop, TransactionIdUnknown
 from .exceptions import NotFound

--- a/btdht/krcp.pyx
+++ b/btdht/krcp.pyx
@@ -19,7 +19,7 @@ from cython.parallel import prange
 
 import six
 
-import utils
+from . import utils
 from .exceptions import MissingT, DecodeError
 
 cdef int str_to_int(char* data, int len) nogil:


### PR DESCRIPTION
error was

```
$ python3 -c "import btdht"
...
  File "/nix/store/vl11kw645rjqd46irlsw2bkch24p9p0i-python3.12-btdht-0.3.3/lib/python3.12/site-packages/btdht/__init__.py", line 13, in <module>
    from btdht.dht import  DHT, DHT_BASE, Node, Bucket, RoutingTable
  File "btdht/dht.pyx", line 1, in init btdht.dht
  File "btdht/krcp.pyx", line 22, in init btdht.krcp
ModuleNotFoundError: No module named 'utils'
```

